### PR TITLE
Fix inconsistent issues

### DIFF
--- a/lib/append_entries_handler.ml
+++ b/lib/append_entries_handler.ml
@@ -19,9 +19,7 @@ open State
  *)
 
 let append_entries ~(conf : Conf.t) ~logger ~state
-    ~(param : Params.append_entries_request) ~(apply_log : Base.apply_log)
-    ~cb_valid_request ~cb_newer_term =
-  cb_valid_request ();
+    ~(param : Params.append_entries_request) ~(apply_log : Base.apply_log) ~cb_newer_term =
   VolatileState.update_leader_id state.volatile_state ~logger param.leader_id;
   let persistent_state = state.persistent_state in
   let persistent_log = state.persistent_log in
@@ -67,6 +65,7 @@ let handle ~conf ~state ~logger ~apply_log ~cb_valid_request ~cb_newer_term
   let persistent_state = state.persistent_state in
   let persistent_log = state.persistent_log in
   let stored_prev_log = PersistentLog.get persistent_log param.prev_log_index in
+  cb_valid_request ();
   let result =
     if PersistentState.detect_old_leader persistent_state ~logger
          ~other_term:param.term
@@ -84,12 +83,10 @@ let handle ~conf ~state ~logger ~apply_log ~cb_valid_request ~cb_newer_term
            "Received a request that doesn't meet requirement.\nparam:%s,\nstate:%s"
            (Params.show_append_entries_request param)
            (PersistentLog.show persistent_log));
-      cb_valid_request ();
       false
     )
     else (
-      append_entries ~conf ~logger ~state ~param ~apply_log ~cb_valid_request
-        ~cb_newer_term;
+      append_entries ~conf ~logger ~state ~param ~apply_log ~cb_newer_term;
       State.log state ~logger;
       true
     )

--- a/lib/append_entries_handler.mli
+++ b/lib/append_entries_handler.mli
@@ -5,6 +5,7 @@ val handle :
   apply_log:Base.apply_log ->
   cb_valid_request:(unit -> unit) ->
   cb_newer_term:(unit -> unit) ->
+  handle_same_term_as_newer:bool ->
   param:Params.append_entries_request ->
   (Cohttp.Response.t * Cohttp_lwt__.Body.t) Lwt.t
 (** Invoked by leader to replicate log entries (§5.3); also used as

--- a/lib/candidate.ml
+++ b/lib/candidate.ml
@@ -168,13 +168,13 @@ let next_mode t =
 
 
 let run t () =
+  VolatileState.reset_leader_id t.state.volatile_state ~logger:t.logger;
   let persistent_state = t.state.persistent_state in
   (* Increment currentTerm *)
   PersistentState.increment_current_term persistent_state;
+  PersistentState.set_voted_for persistent_state ~logger:t.logger ~voted_for:(Some t.conf.node_id);
   Logger.info t.logger @@ Printf.sprintf "### Candidate: Start (term:%d) ###" @@ PersistentState.current_term persistent_state;
   (* Vote for self *)
-  PersistentState.set_voted_for persistent_state ~logger:t.logger
-    ~voted_for:(Some t.conf.node_id);
   State.log t.state ~logger:t.logger;
   (* Reset election timer *)
   let election_timer =

--- a/lib/follower.ml
+++ b/lib/follower.ml
@@ -55,6 +55,7 @@ let request_handlers t ~election_timer =
                * convert to candidate *)
             ~cb_valid_request:(fun () -> Timer.update election_timer)
             ~cb_newer_term:(fun () -> t.next_mode <- FOLLOWER)
+            ~handle_same_term_as_newer:false
             ~param:x
       | _ -> failwith "Unexpected state" );
   Stdlib.Hashtbl.add handlers

--- a/lib/follower.ml
+++ b/lib/follower.ml
@@ -80,6 +80,8 @@ let request_handlers t ~election_timer =
 
 
 let run t () =
+  VolatileState.reset_leader_id t.state.volatile_state ~logger:t.logger;
+  PersistentState.set_voted_for t.state.persistent_state ~logger:t.logger ~voted_for:None;
   Logger.info t.logger @@ Printf.sprintf "### Follower: Start (term:%d) ###" @@ PersistentState.current_term t.state.persistent_state;
   State.log t.state ~logger:t.logger;
   let election_timer =

--- a/lib/leader.ml
+++ b/lib/leader.ml
@@ -244,6 +244,7 @@ let request_handlers t =
                * - If RPC request or response contains term T > currentTerm:
                *   set currentTerm = T, convert to follower (§5.1) *)
             ~cb_newer_term:(fun () -> t.should_step_down <- true)
+            ~handle_same_term_as_newer:false
             ~param:x
       | _ -> failwith "Unexpected state" );
   Stdlib.Hashtbl.add handlers

--- a/lib/leader.ml
+++ b/lib/leader.ml
@@ -293,6 +293,7 @@ let append_entries_thread t ~server_stopper =
 let run t () =
   VolatileState.update_leader_id
     t.state.common.volatile_state ~logger:t.logger t.conf.node_id;
+  PersistentState.set_voted_for t.state.common.persistent_state ~logger:t.logger ~voted_for:(Some t.conf.node_id);
   Logger.info t.logger @@
     Printf.sprintf "### Leader: Start (term:%d) ###" @@ PersistentState.current_term t.state.common.persistent_state;
   State.log_leader t.state ~logger:t.logger;

--- a/lib/leader.ml
+++ b/lib/leader.ml
@@ -172,7 +172,6 @@ let append_entries t =
        n >= Conf.majority_of_nodes t.conf
     then (
       VolatileState.update_commit_index volatile_state last_log_index;
-      VolatileState.update_leader_id volatile_state ~logger:t.logger t.conf.node_id;
       VolatileState.apply_logs volatile_state ~logger:t.logger ~f:(fun i ->
           let log = PersistentLog.get_exn persistent_log i in
           t.apply_log ~node_id:t.conf.node_id ~log_index:log.index
@@ -292,6 +291,8 @@ let append_entries_thread t ~server_stopper =
 
 
 let run t () =
+  VolatileState.update_leader_id
+    t.state.common.volatile_state ~logger:t.logger t.conf.node_id;
   Logger.info t.logger @@
     Printf.sprintf "### Leader: Start (term:%d) ###" @@ PersistentState.current_term t.state.common.persistent_state;
   State.log_leader t.state ~logger:t.logger;

--- a/lib/request_vote_handler.ml
+++ b/lib/request_vote_handler.ml
@@ -21,9 +21,8 @@ let request_vote ~state ~logger ~cb_newer_term
   then false
   else (
     if PersistentState.detect_newer_term persistent_state ~logger ~other_term:param.term
-    then (
-      cb_newer_term ()
-    );
+    then cb_newer_term ()
+    ;
 
     (* If votedFor is null or candidateId, and candidate’s log is at
      * least as up-to-date as receiver’s log, grant vote (§5.2, §5.4) *)

--- a/lib/request_vote_handler.ml
+++ b/lib/request_vote_handler.ml
@@ -39,8 +39,8 @@ let request_vote ~state ~logger ~cb_newer_term
         up_to_date_as_receiver_log
         param.last_log_term
         param.last_log_index
-        last_log_index
-        (match last_log with Some x -> x.term | None -> -1));
+        (match last_log with Some x -> x.term | None -> -1)
+        last_log_index);
 
     match PersistentState.voted_for persistent_state with
     | Some v when param.candidate_id = v -> up_to_date_as_receiver_log

--- a/lib/state.ml
+++ b/lib/state.ml
@@ -300,6 +300,10 @@ module VolatileState = struct
       t.leader_id <- Some leader_id;
       Logger.info logger (sprintf "Leader ID is changed to %d" leader_id)
     )
+
+  let reset_leader_id t ~logger =
+    t.leader_id <- None;
+    Logger.info logger (sprintf "Leader ID is reset")
 end
 
 (* Volatile state on leaders:

--- a/lib/state.mli
+++ b/lib/state.mli
@@ -104,6 +104,8 @@ module VolatileState : sig
   val leader_id : t -> int option
 
   val update_leader_id : t -> logger:Logger.t -> int -> unit
+
+  val reset_leader_id : t -> logger:Logger.t -> unit
 end
 
 (** Volatile state on leaders:

--- a/lib/state.mli
+++ b/lib/state.mli
@@ -21,6 +21,8 @@ module PersistentState : sig
 
   val increment_current_term : t -> unit
 
+  val detect_same_term : t -> logger:Logger.t -> other_term:int -> bool
+
   val detect_newer_term : t -> logger:Logger.t -> other_term:int -> bool
 
   val detect_old_leader : t -> logger:Logger.t -> other_term:int -> bool

--- a/verifier/verifier
+++ b/verifier/verifier
@@ -101,7 +101,7 @@ class Verifier
 
       case response.status
       when 0...200
-        throw_exception("Unexpected response: response=#{response}, command='#{command}', error=#{response.body}")
+        throw_exception("Unexpected response: response.status=#{response.status}, command='#{command}', error=#{response.body}")
       when 200...300
         $logger.debug "Success! command='#{command}'"
         return response.body
@@ -114,7 +114,7 @@ class Verifier
         # Conflict
         return nil
       else # >= 500
-        $logger.warn "Temporary error: command='#{command}', error=#{response.body}"
+        $logger.warn "Temporary error: response.status=#{response.status}, command='#{command}', error=#{response.body}"
         wait(0.1, 2, 1.5, i)
         next
       end


### PR DESCRIPTION
- Reset AppendEntries timeout when receiving too new previous log index
- Stepdown from Candidate when receiving the same term from other Leader
- Initialize leader_id properly at the beginning of each phase