### PR TITLE
Improve `append_entries` request sending

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,9 +9,6 @@ jobs:
       fail-fast: false
       matrix:
         ocaml-compiler:
-          - ocaml-base-compiler.4.11.2
-          - ocaml-base-compiler.4.12.1
-          - ocaml-base-compiler.4.13.1
           - ocaml-base-compiler.4.14.1
           - ocaml-base-compiler.5.0.0
     steps:

--- a/dune-project
+++ b/dune-project
@@ -20,7 +20,7 @@
  (synopsis "Raft consensus algorithm implemented in OCaml")
  (description "Raft consensus algorithm implemented in OCaml")
  (depends
-  (ocaml (>= 4.11.0))
+  (ocaml (>= 4.14.0))
   dune
   (core (>= v0.9.0))
   (core_unix (>= v0.9.0))

--- a/example/oraft-1/conf.json
+++ b/example/oraft-1/conf.json
@@ -8,7 +8,7 @@
         {"id": 5, "host": "localhost", "port": 7895, "app_port": 8185}
     ],
     "log_file": "oraft.log",
-    "log_level": "INFO",
+    "log_level": "DEBUG",
     "state_dir": "state",
     "election_timeout_millis": 200,
     "heartbeat_interval_millis": 50,

--- a/example/oraft-2/conf.json
+++ b/example/oraft-2/conf.json
@@ -8,7 +8,7 @@
         {"id": 5, "host": "localhost", "port": 7895, "app_port": 8185}
     ],
     "log_file": "oraft.log",
-    "log_level": "INFO",
+    "log_level": "DEBUG",
     "state_dir": "state",
     "election_timeout_millis": 200,
     "heartbeat_interval_millis": 50,

--- a/example/oraft-3/conf.json
+++ b/example/oraft-3/conf.json
@@ -8,7 +8,7 @@
         {"id": 5, "host": "localhost", "port": 7895, "app_port": 8185}
     ],
     "log_file": "oraft.log",
-    "log_level": "INFO",
+    "log_level": "DEBUG",
     "state_dir": "state",
     "election_timeout_millis": 200,
     "heartbeat_interval_millis": 50,

--- a/example/oraft-4/conf.json
+++ b/example/oraft-4/conf.json
@@ -8,7 +8,7 @@
         {"id": 5, "host": "localhost", "port": 7895, "app_port": 8185}
     ],
     "log_file": "oraft.log",
-    "log_level": "INFO",
+    "log_level": "DEBUG",
     "state_dir": "state",
     "election_timeout_millis": 200,
     "heartbeat_interval_millis": 50,

--- a/example/oraft-5/conf.json
+++ b/example/oraft-5/conf.json
@@ -8,7 +8,7 @@
         {"id": 5, "host": "localhost", "port": 7895, "app_port": 8185}
     ],
     "log_file": "oraft.log",
-    "log_level": "INFO",
+    "log_level": "DEBUG",
     "state_dir": "state",
     "election_timeout_millis": 200,
     "heartbeat_interval_millis": 50,

--- a/lib/append_entries_handler.ml
+++ b/lib/append_entries_handler.ml
@@ -69,13 +69,21 @@ let append_entries ~(conf : Conf.t) ~logger ~state
 let log_error_req ~state ~logger ~msg ~(param : Params.append_entries_request) =
   let entries_size = List.length param.entries in
   let persistent_log = state.persistent_log in
+  let first_entry =
+    if entries_size = 0
+    then "None"
+    else PersistentLogEntry.show (List.nth_exn param.entries 0)
+  in
+  let last_entry =
+    if entries_size = 0
+    then "None"
+    else PersistentLogEntry.show (List.nth_exn param.entries (entries_size - 1))
+  in
   Logger.warn logger
     (Printf.sprintf
        "%s. param:{term:%d, leader_id:%d, prev_log_term:%d, prev_log_index:%d, entries_size:%d, leader_commit:%d, first_entry:%s, last_entry:%s}, state:%s"
        msg param.term param.leader_id param.prev_log_term param.prev_log_index
-       entries_size param.leader_commit
-       (PersistentLogEntry.show (List.nth_exn param.entries 0))
-       (PersistentLogEntry.show (List.nth_exn param.entries (entries_size - 1)))
+       entries_size param.leader_commit first_entry last_entry
        (PersistentLog.show persistent_log)
     )
 

--- a/lib/append_entries_sender.ml
+++ b/lib/append_entries_sender.ml
@@ -59,8 +59,9 @@ let send_request_and_update_peer_info t ~node_index ~node ~request_json ~entries
        (Yojson.Safe.to_string request_json)
     );
   let node = Conf.peer_node t.conf ~node_id:node.id in
-  Request_sender.post node ~logger:t.logger ~url_path:"append_entries"
-    ~request_json ~timeout_millis:t.conf.request_timeout_millis
+  Request_sender.post node ~my_node_id:t.conf.node_id ~logger:t.logger
+    ~url_path:"append_entries" ~request_json
+    ~timeout_millis:t.conf.request_timeout_millis
     ~converter:(fun response_json ->
       match Params.append_entries_response_of_yojson response_json with
       | Ok param ->

--- a/lib/append_entries_sender.ml
+++ b/lib/append_entries_sender.ml
@@ -27,14 +27,9 @@ let return_responses t =
     List.sort ~compare:(fun a b -> a - b) match_indexes
   in
   let num_of_majority = Conf.majority_of_nodes t.conf in
-  (* FIXME *)
-  Logger.info t.logger (sprintf "DEBUG: num_of_majority=%d" num_of_majority);
   let match_index_with_majority =
     List.nth_exn ordered_match_indexes (num_of_majority - 1)
   in
-  (* FIXME *)
-  Logger.info t.logger
-    (sprintf "DEBUG: match_index_with_majority=%d" match_index_with_majority);
   (* TODO: Optimization *)
   Queue.filter_inplace
     ~f:(fun (log_index, lock) ->

--- a/lib/append_entries_sender.ml
+++ b/lib/append_entries_sender.ml
@@ -1,0 +1,225 @@
+open Core
+open Lwt
+open State
+
+type t = {
+  conf : Conf.t;
+  state : leader;
+  logger : Logger.t;
+  node_id : int;
+  step_down : unit -> unit;
+  should_step_down : bool;
+  mutable last_request_ts : Core.Time_ns.t;
+  inflight_requests : (int * Lwt_mutex.t) Queue.t;
+  mutable thread : unit Lwt.t option;
+}
+
+type lock = Lwt_mutex.t
+
+let lock = Lwt_mutex.create ()
+
+let send_request_and_update_peer_info t ~node_id ~request_json ~entries
+    ~prev_log_index =
+  let persistent_state = t.state.common.persistent_state in
+  let leader_state = t.state.volatile_state_on_leader in
+  Logger.debug t.logger
+    (Printf.sprintf "Sending append_entries(node_id:%d): %s" t.node_id
+       (Yojson.Safe.to_string request_json)
+    );
+  let node = Conf.peer_node t.conf ~node_id in
+  Request_sender.post node ~logger:t.logger ~url_path:"append_entries"
+    ~request_json ~timeout_millis:t.conf.request_timeout_millis
+    ~converter:(fun response_json ->
+      match Params.append_entries_response_of_yojson response_json with
+      | Ok param ->
+          if PersistentState.detect_newer_term persistent_state ~logger:t.logger
+               ~other_term:param.term
+          then t.step_down ();
+
+          if param.success
+          then (
+            (* If successful: update nextIndex and matchIndex for follower (§5.3) *)
+            VolatileStateOnLeader.set_match_index leader_state ~logger:t.logger
+              node_id
+              (prev_log_index + List.length entries);
+            let match_index =
+              VolatileStateOnLeader.match_index leader_state node_id
+            in
+            VolatileStateOnLeader.set_next_index leader_state node_id
+              (match_index + 1);
+            (* All Servers:
+               * - If RPC request or response contains term T > currentTerm:
+               *   set currentTerm = T, convert to follower (§5.1)
+            *)
+            Ok (Params.APPEND_ENTRIES_RESPONSE param)
+          )
+          else (
+            (* If AppendEntries fails because of log inconsistency:
+                *  decrement nextIndex and retry (§5.3) *)
+            let next_index =
+              VolatileStateOnLeader.next_index leader_state node_id
+            in
+            if next_index > 1
+            then
+              VolatileStateOnLeader.set_next_index leader_state node_id
+                (next_index - 1);
+            Error (sprintf "Need to try with decremented index(%d)" t.node_id)
+          )
+      | Error _ as err -> err
+  )
+
+
+let prepare_entries t ~node_id =
+  let leader_state = t.state.volatile_state_on_leader in
+  let persistent_log = t.state.common.persistent_log in
+  let prev_log_index =
+    VolatileStateOnLeader.next_index leader_state node_id - 1
+  in
+  let last_log_index = PersistentLog.last_index persistent_log in
+  let prev_log_term =
+    match PersistentLog.get persistent_log prev_log_index with
+    | Some log -> log.term
+    | None -> -1
+  in
+  let entries =
+    List.init (last_log_index - prev_log_index) ~f:(fun i ->
+        let idx = i + prev_log_index + 1 in
+        match PersistentLog.get persistent_log idx with
+        | Some x -> Some x
+        | None ->
+            let msg =
+              Printf.sprintf "Can't find the log(%d): i:%d, prev_log_index:%d"
+                t.node_id i prev_log_index
+            in
+            Logger.error t.logger msg;
+            None
+    )
+  in
+  (prev_log_index, prev_log_term, List.filter_map ~f:(fun x -> x) entries)
+
+
+let request_append_entry t ~node_id =
+  let persistent_state = t.state.common.persistent_state in
+  let volatile_state = t.state.common.volatile_state in
+  let leader_state = t.state.volatile_state_on_leader in
+  let current_term = PersistentState.current_term persistent_state in
+  Logger.debug t.logger
+    (Printf.sprintf "Peer[%d]: %s" node_id
+       (VolatileStateOnLeader.show_nth_peer leader_state node_id)
+    );
+  (* If last log index ≥ nextIndex for a follower: send
+   * AppendEntries RPC with log entries starting at nextIndex
+   * - If successful: update nextIndex and matchIndex for
+   *   follower (§5.3)
+   * - If AppendEntries fails because of log inconsistency:
+   *   decrement nextIndex and retry (§5.3)
+   *)
+  let prev_log_index, prev_log_term, entries = prepare_entries t ~node_id in
+  let request_json =
+    let r : Params.append_entries_request =
+      {
+        term = current_term;
+        leader_id = t.conf.node_id;
+        prev_log_term;
+        prev_log_index;
+        entries;
+        leader_commit = VolatileState.commit_index volatile_state;
+      }
+    in
+    Params.append_entries_request_to_yojson r
+  in
+  send_request_and_update_peer_info t ~node_id ~entries ~request_json
+    ~prev_log_index
+
+
+let heartbeat_interval t =
+  Time_ns.Span.create ~ms:t.conf.heartbeat_interval_millis ()
+
+
+let send_append_entries_if_needed t ~node_id =
+  let interval = heartbeat_interval t in
+  let now = Time_ns.now () in
+  let next_heartbeat = Time_ns.add t.last_request_ts interval in
+  if Time_ns.is_earlier next_heartbeat ~than:now
+  then (
+    t.last_request_ts <- now;
+    request_append_entry t ~node_id
+  )
+  else Lwt.return_none
+
+
+let conf_interval t =
+  Time_ns.Span.create ~ms:t.conf.heartbeat_interval_millis ()
+
+
+let divided_conf_interval_seconds t n =
+  float_of_int t.conf.heartbeat_interval_millis /. float_of_int n /. 1000.0
+
+
+let append_entries_thread t ~node_id =
+  State.log_leader t.state ~logger:t.logger;
+  let n = 20 in
+  let sleep_interval_seconds = divided_conf_interval_seconds t n in
+  let i = ref 0 in
+  let rec loop () =
+    if t.should_step_down
+    then Lwt.return ()
+    else (
+      let proc =
+        if !i = 0 || !i >= n
+        then (
+          State.log_leader t.state ~logger:t.logger;
+          i := 1;
+          Lwt_mutex.with_lock lock (fun () ->
+              (* TODO: Consider to wrap all the accesses to should_step_down with the lock *)
+              if t.should_step_down
+              then (
+                Logger.info t.logger
+                  (sprintf
+                     "Avoiding sending append_entries since it's stepping down(%d)"
+                     t.node_id
+                  );
+                Lwt.return_unit
+              )
+              else
+                send_append_entries_if_needed t ~node_id >>= fun _ ->
+                Lwt.return_unit
+          )
+        )
+        else (
+          i := !i + 1;
+          Lwt.return_unit
+        )
+      in
+      proc >>= fun () ->
+      Lwt_unix.sleep sleep_interval_seconds >>= fun () -> loop ()
+    )
+  in
+  loop ()
+
+
+(* FIXME *)
+let stop _ = ()
+
+(* FIXME *)
+let wait_append_entries_response _ ~log_index =
+  if log_index > 0 then lock else lock
+
+
+let create ~conf ~state ~logger ~node_id ~step_down =
+  let t =
+    {
+      conf;
+      state;
+      logger;
+      node_id;
+      step_down;
+      should_step_down = false;
+      last_request_ts = Time_ns.min_value_representable;
+      inflight_requests = Queue.create ();
+      thread = None;
+    }
+  in
+  let thread = append_entries_thread t ~node_id in
+  t.thread <- Some thread;
+  t

--- a/lib/append_entries_sender.ml
+++ b/lib/append_entries_sender.ml
@@ -27,9 +27,14 @@ let return_responses t =
     List.sort ~compare:(fun a b -> a - b) match_indexes
   in
   let num_of_majority = Conf.majority_of_nodes t.conf in
+  (* FIXME *)
+  Logger.info t.logger (sprintf "DEBUG: num_of_majority=%d" num_of_majority);
   let match_index_with_majority =
     List.nth_exn ordered_match_indexes (num_of_majority - 1)
   in
+  (* FIXME *)
+  Logger.info t.logger
+    (sprintf "DEBUG: match_index_with_majority=%d" match_index_with_majority);
   (* TODO: Optimization *)
   Queue.filter_inplace
     ~f:(fun (log_index, lock) ->

--- a/lib/append_entries_sender.mli
+++ b/lib/append_entries_sender.mli
@@ -1,0 +1,13 @@
+type t
+type lock
+
+val create :
+  conf:Conf.t ->
+  state:State.leader ->
+  logger:Logger.t ->
+  node_id:int ->
+  step_down:(unit -> unit) ->
+  t
+
+val stop : t -> unit
+val wait_append_entries_response : t -> log_index:int -> lock

--- a/lib/append_entries_sender.mli
+++ b/lib/append_entries_sender.mli
@@ -1,13 +1,12 @@
 type t
-type lock
 
 val create :
   conf:Conf.t ->
   state:State.leader ->
   logger:Logger.t ->
-  node_id:int ->
   step_down:(unit -> unit) ->
   t
 
 val stop : t -> unit
-val wait_append_entries_response : t -> log_index:int -> lock
+val wait_append_entries_response : t -> log_index:int -> unit Lwt.t
+val wait_termination : t -> unit Lwt.t

--- a/lib/candidate.ml
+++ b/lib/candidate.ml
@@ -67,8 +67,7 @@ let request_vote t ~election_timer =
     Params.request_vote_request_to_yojson r
   in
   let request =
-    Request_sender.post ~node_id:t.conf.node_id ~logger:t.logger
-      ~url_path:"request_vote" ~request_json
+    Request_sender.post ~logger:t.logger ~url_path:"request_vote" ~request_json
       ~timeout_millis:t.conf.request_timeout_millis
       ~converter:(fun response_json ->
         match Params.request_vote_response_of_yojson response_json with

--- a/lib/candidate.ml
+++ b/lib/candidate.ml
@@ -68,7 +68,7 @@ let request_vote t ~election_timer =
   in
   let request =
     Request_sender.post ~logger:t.logger ~url_path:"request_vote" ~request_json
-      ~timeout_millis:t.conf.request_timeout_millis
+      ~timeout_millis:t.conf.request_timeout_millis ~my_node_id:t.conf.node_id
       ~converter:(fun response_json ->
         match Params.request_vote_response_of_yojson response_json with
         | Ok param ->

--- a/lib/dune
+++ b/lib/dune
@@ -2,5 +2,5 @@
  (name oraft)
  (public_name oraft)
  (libraries str core core_unix.command_unix cohttp-lwt-unix yojson sqlite3)
- (preprocess (pps ppx_deriving.std ppx_deriving_yojson)))
+ (preprocess (pps lwt_ppx ppx_deriving.std ppx_deriving_yojson)))
 

--- a/lib/leader.ml
+++ b/lib/leader.ml
@@ -25,7 +25,6 @@ open State
  *   set commitIndex = N (§5.3, §5.4).
  *)
 let mode = LEADER
-let lock = Lwt_mutex.create ()
 
 type t = {
   conf : Conf.t;
@@ -204,6 +203,7 @@ let run t () =
   @@ PersistentState.current_term t.state.common.persistent_state;
   State.log_leader t.state ~logger:t.logger;
   let handlers = request_handlers t in
+  let lock = Lwt_mutex.create () in
   let server, server_stopper =
     Request_dispatcher.create ~port:(Conf.my_node t.conf).port ~logger:t.logger
       ~lock ~table:handlers

--- a/lib/leader.ml
+++ b/lib/leader.ml
@@ -33,7 +33,7 @@ type t = {
   apply_log : apply_log;
   state : State.leader;
   mutable should_step_down : bool;
-  mutable last_request_ts : Time_ns.t option;
+  threads : Append_entries_sender.t list;
 }
 
 let init ~conf ~apply_log ~state =
@@ -52,121 +52,12 @@ let init ~conf ~apply_log ~state =
             ~last_log_index:(PersistentLog.last_index state.persistent_log);
       };
     should_step_down = false;
-    last_request_ts = None;
   }
 
 
 let step_down t =
   Logger.info t.logger "Stepping down";
   t.should_step_down <- true
-
-
-let prepare_entries t i =
-  let leader_state = t.state.volatile_state_on_leader in
-  let persistent_log = t.state.common.persistent_log in
-  let prev_log_index = VolatileStateOnLeader.next_index leader_state i - 1 in
-  let last_log_index = PersistentLog.last_index persistent_log in
-  let prev_log_term =
-    match PersistentLog.get persistent_log prev_log_index with
-    | Some log -> log.term
-    | None -> -1
-  in
-  let entries =
-    List.init (last_log_index - prev_log_index) ~f:(fun i ->
-        let idx = i + prev_log_index + 1 in
-        match PersistentLog.get persistent_log idx with
-        | Some x -> Some x
-        | None ->
-            let msg =
-              Printf.sprintf "Can't find the log: i:%d, prev_log_index:%d" i
-                prev_log_index
-            in
-            Logger.error t.logger msg;
-            None
-    )
-  in
-  (prev_log_index, prev_log_term, List.filter_map ~f:(fun x -> x) entries)
-
-
-let send_request_and_update_peer_info t i ~request_json ~entries ~prev_log_index
-    =
-  let persistent_state = t.state.common.persistent_state in
-  let leader_state = t.state.volatile_state_on_leader in
-  Logger.debug t.logger
-    (Printf.sprintf "Sending append_entries: %s"
-       (Yojson.Safe.to_string request_json)
-    );
-  Request_sender.post ~node_id:t.conf.node_id ~logger:t.logger
-    ~url_path:"append_entries" ~request_json
-    ~timeout_millis:t.conf.request_timeout_millis
-    ~converter:(fun response_json ->
-      match Params.append_entries_response_of_yojson response_json with
-      | Ok param ->
-          if PersistentState.detect_newer_term persistent_state ~logger:t.logger
-               ~other_term:param.term
-          then step_down t;
-
-          if param.success
-          then (
-            (* If successful: update nextIndex and matchIndex for follower (§5.3) *)
-            VolatileStateOnLeader.set_match_index leader_state ~logger:t.logger
-              i
-              (prev_log_index + List.length entries);
-            let match_index =
-              VolatileStateOnLeader.match_index leader_state i
-            in
-            VolatileStateOnLeader.set_next_index leader_state i (match_index + 1);
-            (* All Servers:
-               * - If RPC request or response contains term T > currentTerm:
-               *   set currentTerm = T, convert to follower (§5.1)
-            *)
-            Ok (Params.APPEND_ENTRIES_RESPONSE param)
-          )
-          else (
-            (* If AppendEntries fails because of log inconsistency:
-                *  decrement nextIndex and retry (§5.3) *)
-            let next_index = VolatileStateOnLeader.next_index leader_state i in
-            if next_index > 1
-            then
-              VolatileStateOnLeader.set_next_index leader_state i
-                (next_index - 1);
-            Error "Need to try with decremented index"
-          )
-      | Error _ as err -> err
-  )
-
-
-let request_append_entry t i =
-  let persistent_state = t.state.common.persistent_state in
-  let volatile_state = t.state.common.volatile_state in
-  let leader_state = t.state.volatile_state_on_leader in
-  let current_term = PersistentState.current_term persistent_state in
-  Logger.debug t.logger
-    (Printf.sprintf "Peer[%d]: %s" i
-       (VolatileStateOnLeader.show_nth_peer leader_state i)
-    );
-  (* If last log index ≥ nextIndex for a follower: send
-   * AppendEntries RPC with log entries starting at nextIndex
-   * - If successful: update nextIndex and matchIndex for
-   *   follower (§5.3)
-   * - If AppendEntries fails because of log inconsistency:
-   *   decrement nextIndex and retry (§5.3)
-   *)
-  let prev_log_index, prev_log_term, entries = prepare_entries t i in
-  let request_json =
-    let r : Params.append_entries_request =
-      {
-        term = current_term;
-        leader_id = t.conf.node_id;
-        prev_log_term;
-        prev_log_index;
-        entries;
-        leader_commit = VolatileState.commit_index volatile_state;
-      }
-    in
-    Params.append_entries_request_to_yojson r
-  in
-  send_request_and_update_peer_info t i ~entries ~request_json ~prev_log_index
 
 
 let append_entries t =
@@ -209,44 +100,8 @@ let append_entries t =
       )
       else false
     in
-    t.last_request_ts <- Some (Time_ns.now ());
     Lwt.return result
   )
-
-
-let send_append_entries_if_needed t =
-  let interval = Time_ns.Span.create ~ms:t.conf.heartbeat_interval_millis () in
-  let leader_state = t.state.volatile_state_on_leader in
-  let now = Time_ns.now () in
-  Lwt_list.mapi_p
-    (fun i node ->
-      let next_heartbeat =
-        VolatileStateOnLeader.next_heartbeat leader_state i
-      in
-      if Time_ns.is_earlier next_heartbeat ~than:now
-      then (
-        let next_heartbeat = Time_ns.add now interval in
-        VolatileStateOnLeader.set_next_heartbeat leader_state i next_heartbeat;
-        request_append_entry t i node
-      )
-      else Lwt.return_none
-    )
-    (Conf.peer_nodes t.conf)
-
-
-let heartbeat_span_sec t =
-  let configured =
-    Time_ns.Span.create ~ms:t.conf.heartbeat_interval_millis ()
-  in
-  let now = Time_ns.now () in
-  let wait =
-    match t.last_request_ts with
-    | Some x ->
-        let next_fire_ts = Time_ns.add x configured in
-        Time_ns.diff next_fire_ts now
-    | None -> configured
-  in
-  Time_ns.Span.to_sec wait
 
 
 let handle_client_command t ~(param : Params.client_command_request) =
@@ -335,48 +190,6 @@ let request_handlers t =
       | _ -> unexpected_request ()
     );
   handlers
-
-
-let append_entries_thread t ~server_stopper =
-  State.log_leader t.state ~logger:t.logger;
-  let n = 20 in
-  let sleep = heartbeat_span_sec t /. float_of_int n in
-  let i = ref 0 in
-  let rec loop () =
-    if t.should_step_down
-    then (
-      Logger.debug t.logger "Stopping server";
-      Lwt.wakeup server_stopper ();
-      Logger.debug t.logger "Stopped server";
-      Lwt.return ()
-    )
-    else (
-      let proc =
-        if !i = 0 || !i >= n
-        then (
-          State.log_leader t.state ~logger:t.logger;
-          i := 1;
-          Lwt_mutex.with_lock lock (fun () ->
-              (* TODO: Consider to wrap all the accesses to should_step_down with the lock *)
-              if t.should_step_down
-              then (
-                Logger.info t.logger
-                  "Avoiding sending append_entries since it's stepping down";
-                Lwt.return_unit
-              )
-              else send_append_entries_if_needed t >>= fun _ -> Lwt.return_unit
-          )
-        )
-        else (
-          i := !i + 1;
-          Lwt.return_unit
-        )
-      in
-      proc >>= fun () ->
-      Lwt_unix.sleep sleep >>= fun () -> loop ()
-    )
-  in
-  loop ()
 
 
 let run t () =

--- a/lib/leader.ml
+++ b/lib/leader.ml
@@ -357,6 +357,7 @@ let append_entries_thread t ~server_stopper =
           State.log_leader t.state ~logger:t.logger;
           i := 1;
           Lwt_mutex.with_lock lock (fun () ->
+              (* TODO: Consider to wrap all the accesses to should_step_down with the lock *)
               if t.should_step_down
               then (
                 Logger.info t.logger

--- a/lib/leader.ml
+++ b/lib/leader.ml
@@ -223,7 +223,7 @@ let send_append_entries_if_needed t =
       let next_heartbeat =
         VolatileStateOnLeader.next_heartbeat leader_state i
       in
-      if Time_ns.is_earlier now ~than:next_heartbeat
+      if Time_ns.is_earlier next_heartbeat ~than:now
       then (
         let next_heartbeat = Time_ns.add now interval in
         VolatileStateOnLeader.set_next_heartbeat leader_state i next_heartbeat;

--- a/lib/logger.ml
+++ b/lib/logger.ml
@@ -47,7 +47,7 @@ let write t ~level ~msg =
   then (
     let now =
       Core.Time_ns.to_string_iso8601_basic (Core.Time_ns.now ())
-        ~zone:Core.Time.Zone.utc
+        ~zone:Core.Time_float.Zone.utc
     in
     let msg = Str.(global_replace (regexp "\n") "" msg) in
     let s =

--- a/lib/oraft.ml
+++ b/lib/oraft.ml
@@ -41,7 +41,7 @@ let post_command ~(conf : Conf.t) ~logger ~state s =
     Params.client_command_request_to_yojson r
   in
   let request =
-    Request_sender.post ~node_id:conf.node_id ~logger ~url_path:"client_command"
+    Request_sender.post ~logger ~url_path:"client_command"
       ~request_json
         (* Afford to allow a connection timeout to unavailable server *)
       ~timeout_millis:(conf.request_timeout_millis * 2)

--- a/lib/oraft.ml
+++ b/lib/oraft.ml
@@ -42,6 +42,7 @@ let post_command ~(conf : Conf.t) ~logger ~state s =
   in
   let request =
     Request_sender.post ~logger ~url_path:"client_command"
+      ~my_node_id:conf.node_id
       ~request_json
         (* Afford to allow a connection timeout to unavailable server *)
       ~timeout_millis:(conf.request_timeout_millis * 2)

--- a/lib/request_sender.ml
+++ b/lib/request_sender.ml
@@ -29,12 +29,13 @@ let handle_response ~logger ~converter ~node ~resp ~body =
 
 
 let post ~logger ~url_path ~request_json ~timeout_millis
-    ~(converter : Yojson.Safe.t -> (Params.response, string) Result.t) node =
+    ~(converter : Yojson.Safe.t -> (Params.response, string) Result.t)
+    ~my_node_id node =
   let request_param =
     request_json |> Yojson.Safe.to_string |> Cohttp_lwt.Body.of_string
   in
   let headers =
-    Cohttp.Header.init_with "X-Raft-Node-Id" (string_of_int node.id)
+    Cohttp.Header.init_with "X-Raft-Node-Id" (string_of_int my_node_id)
   in
   let timeout : Params.response option Lwt.t =
     Lwt_unix.sleep (float_of_int timeout_millis /. 1000.0) >>= fun () ->

--- a/lib/request_sender.ml
+++ b/lib/request_sender.ml
@@ -28,13 +28,13 @@ let handle_response ~logger ~converter ~node ~resp ~body =
   )
 
 
-let post ~node_id ~logger ~url_path ~request_json ~timeout_millis
+let post ~logger ~url_path ~request_json ~timeout_millis
     ~(converter : Yojson.Safe.t -> (Params.response, string) Result.t) node =
   let request_param =
     request_json |> Yojson.Safe.to_string |> Cohttp_lwt.Body.of_string
   in
   let headers =
-    Cohttp.Header.init_with "X-Raft-Node-Id" (string_of_int node_id)
+    Cohttp.Header.init_with "X-Raft-Node-Id" (string_of_int node.id)
   in
   let timeout : Params.response option Lwt.t =
     Lwt_unix.sleep (float_of_int timeout_millis /. 1000.0) >>= fun () ->

--- a/lib/request_sender.mli
+++ b/lib/request_sender.mli
@@ -4,5 +4,6 @@ val post :
   request_json:Yojson.Safe.t ->
   timeout_millis:int ->
   converter:(Yojson.Safe.t -> (Params.response, string) Core.Result.t) ->
+  my_node_id:int ->
   Base.node ->
   Params.response option Lwt.t

--- a/lib/request_sender.mli
+++ b/lib/request_sender.mli
@@ -1,5 +1,4 @@
 val post :
-  node_id:int ->
   logger:Logger.t ->
   url_path:string ->
   request_json:Yojson.Safe.t ->

--- a/lib/state.ml
+++ b/lib/state.ml
@@ -371,9 +371,6 @@ module VolatileStateOnLeader = struct
     (* For each server, index of highest log entry known to be replicated on server
      * (initialized to 0, increases monotonically) *)
     mutable match_index : int;
-    (* Next heartbeat timing. This isn't mentioned on the original paper *)
-    (* TODO: Fix "opaque" *)
-    mutable next_heartbeat : Time_ns.t; [@opaque]
   }
   [@@deriving show]
 
@@ -381,11 +378,7 @@ module VolatileStateOnLeader = struct
 
   let create ~n ~last_log_index =
     List.init n ~f:(fun _ ->
-        {
-          next_index = last_log_index + 1;
-          match_index = 0;
-          next_heartbeat = Time_ns.min_value_representable;
-        }
+        { next_index = last_log_index + 1; match_index = 0 }
     )
 
 
@@ -405,11 +398,9 @@ module VolatileStateOnLeader = struct
     else peer.match_index <- x
 
 
-  let set_next_heartbeat t i x = (get t i).next_heartbeat <- x
   let show_nth_peer t i = get t i |> show_peer
   let next_index t i = (get t i).next_index
   let match_index t i = (get t i).match_index
-  let next_heartbeat t i = (get t i).next_heartbeat
 end
 
 type common = {

--- a/lib/state.mli
+++ b/lib/state.mli
@@ -4,29 +4,17 @@ module PersistentState : sig
   type t
 
   val to_yojson : t -> Yojson.Safe.t
-
   val of_yojson : Yojson.Safe.t -> t Ppx_deriving_yojson_runtime.error_or
-
   val load : state_dir:string -> t
-
   val save : t -> unit
-
   val log : t -> logger:Logger.t -> unit
-
   val current_term : t -> int
-
   val update_current_term : t -> term:int -> unit
-
   val increment_current_term : t -> unit
-
   val detect_same_term : t -> logger:Logger.t -> other_term:int -> bool
-
   val detect_newer_term : t -> logger:Logger.t -> other_term:int -> bool
-
   val detect_old_leader : t -> logger:Logger.t -> other_term:int -> bool
-
   val voted_for : t -> int option
-
   val set_voted_for : t -> logger:Logger.t -> voted_for:int option -> unit
 end
 
@@ -35,15 +23,10 @@ module PersistentLogEntry : sig
   type t = { term : int; index : int; data : string }
 
   val pp : Format.formatter -> t -> unit
-
   val show : t -> string
-
   val to_yojson : t -> Yojson.Safe.t
-
   val of_yojson : Yojson.Safe.t -> t Ppx_deriving_yojson_runtime.error_or
-
   val from_string : 'a -> 'a
-
   val log : t -> logger:Logger.t -> unit
 end
 
@@ -51,19 +34,12 @@ module PersistentLog : sig
   type t
 
   val load : state_dir:string -> logger:Logger.t -> t
-
   val show : t -> string
-
   val log : t -> logger:Logger.t -> unit
-
   val get : t -> int -> PersistentLogEntry.t option
-
   val get_exn : t -> int -> PersistentLogEntry.t
-
   val last_index : t -> int
-
   val last_log : t -> PersistentLogEntry.t
-
   val append : t -> entries:PersistentLogEntry.t list -> unit
 end
 
@@ -72,30 +48,20 @@ module VolatileState : sig
   type t
 
   val create : unit -> t
-
   val log : t -> logger:Logger.t -> unit
-
   val update_commit_index : t -> int -> unit
-
   val update_last_applied : t -> int -> unit
-
   val commit_index : t -> int
-
   val detect_higher_commit_index : t -> logger:Logger.t -> other:int -> bool
-
   val last_applied : t -> int
-
   val apply_logs : t -> logger:Logger.t -> f:(int -> unit) -> unit
 
-  (** These are customized functions that aren't shown in the paper *)
   val mode : t -> Base.mode
+  (** These are customized functions that aren't shown in the paper *)
 
   val update_mode : t -> logger:Logger.t -> Base.mode -> unit
-
   val leader_id : t -> int option
-
   val update_leader_id : t -> logger:Logger.t -> int -> unit
-
   val reset_leader_id : t -> logger:Logger.t -> unit
 end
 
@@ -103,24 +69,18 @@ end
   * (Reinitialized after election) *)
 module VolatileStateOnLeader : sig
   type peer
-
   type t = peer list
 
-  val create : n:int -> last_log_index:int -> peer list
-
+  val create : n:int -> last_log_index:int -> t
   val log : t -> logger:Logger.t -> unit
-
   val get : 'a list -> int -> 'a
-
-  val set_next_index : peer list -> int -> int -> unit
-
-  val set_match_index : peer list -> logger:Logger.t -> int -> int -> unit
-
+  val set_next_index : t -> int -> int -> unit
+  val set_match_index : t -> logger:Logger.t -> int -> int -> unit
+  val set_next_heartbeat : t -> int -> Core.Time_ns.t -> unit
   val show_nth_peer : t -> int -> string
-
   val next_index : t -> int -> int
-
   val match_index : t -> int -> int
+  val next_heartbeat : t -> int -> Core.Time_ns.t
 end
 
 type common = {

--- a/lib/state.mli
+++ b/lib/state.mli
@@ -76,11 +76,9 @@ module VolatileStateOnLeader : sig
   val get : 'a list -> int -> 'a
   val set_next_index : t -> int -> int -> unit
   val set_match_index : t -> logger:Logger.t -> int -> int -> unit
-  val set_next_heartbeat : t -> int -> Core.Time_ns.t -> unit
   val show_nth_peer : t -> int -> string
   val next_index : t -> int -> int
   val match_index : t -> int -> int
-  val next_heartbeat : t -> int -> Core.Time_ns.t
 end
 
 type common = {

--- a/oraft.opam
+++ b/oraft.opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/komamitsu/oraft"
 doc: "https://github.com/komamitsu/oraft"
 bug-reports: "https://github.com/komamitsu/oraft/issues"
 depends: [
-  "ocaml" {>= "4.11.0"}
+  "ocaml" {>= "4.14.0"}
   "dune" {>= "3.6"}
   "core" {>= "v0.9.0"}
   "core_unix" {>= "v0.9.0"}

--- a/verifier/verifier
+++ b/verifier/verifier
@@ -282,7 +282,7 @@ class KeySetVerifier < Verifier
       $logger.info "All good"
       separator_line
       return true
-    elsif failed <= (expected / 2)
+    elsif failed <= (expected.size / 2)
       $logger.info "Detected a few failures: failed_count=#{failed}. But it's possible that one or two nodes hasn't applied latest entries. Let me check again..."
       sleep 5
       failed = checker.call


### PR DESCRIPTION
## Context

In current Oraft `append_entries` request is sent by
- A thread which gets up after a sleep repeatedly
- A server thread which receives a `client_command` request

In the both case, `append_entries` requests are sent to all the replicas at once. But it's not efficient by sending unnecessary requests.

## Changes

This PR changes the logic of `append_entries` request sending as follows:
- A thread is prepared for each replica
- The individual thread waits for a specific time and sends a request
- When the server thread receives a `client_command` request, it waits until the majority of the replicas save the log, and then returns a response to the client



