### PR TITLE
Simplify Oraft I/F

### DIFF
--- a/example-kv/oraft_kv.ml
+++ b/example-kv/oraft_kv.ml
@@ -157,4 +157,4 @@ let _ =
   in
   let oraft = oraft conf_file in
   let server = server port oraft in
-  Lwt.join [ server; oraft.process ] |> Lwt_main.run
+  Lwt.join [ server ] |> Lwt_main.run

--- a/example-simple/oraft_simple.ml
+++ b/example-simple/oraft_simple.ml
@@ -14,7 +14,7 @@ let main ~conf_file =
         let%lwt _ = Lwt_io.printl (if result then "OK" else "ERR") in
         loop ()
       in
-      Lwt.join [ loop (); oraft.process ] |> Lwt_main.run
+      Lwt.join [ loop () ] |> Lwt_main.run
   | Error msg -> failwith msg
 
 

--- a/lib/candidate.ml
+++ b/lib/candidate.ml
@@ -221,7 +221,7 @@ let next_mode t =
       CANDIDATE
 
 
-let run ~conf ~apply_log ~state () =
+let run ~conf ~apply_log ~state =
   init ~conf ~apply_log ~state >>= fun t ->
   VolatileState.reset_leader_id t.state.volatile_state ~logger:t.logger;
   let persistent_state = t.state.persistent_state in

--- a/lib/candidate.mli
+++ b/lib/candidate.mli
@@ -4,5 +4,4 @@ val run :
   conf:Conf.t ->
   apply_log:Base.apply_log ->
   state:State.common ->
-  unit ->
   (Base.mode Lwt.t, string) result

--- a/lib/follower.ml
+++ b/lib/follower.ml
@@ -101,7 +101,7 @@ let request_handlers t ~election_timer =
   handlers
 
 
-let run ~conf ~apply_log ~state () =
+let run ~conf ~apply_log ~state =
   init ~conf ~apply_log ~state >>= fun t ->
   VolatileState.reset_leader_id t.state.volatile_state ~logger:t.logger;
   PersistentState.set_voted_for t.state.persistent_state ~logger:t.logger

--- a/lib/follower.mli
+++ b/lib/follower.mli
@@ -4,5 +4,4 @@ val run :
   conf:Conf.t ->
   apply_log:Base.apply_log ->
   state:State.common ->
-  unit ->
   (Base.mode Lwt.t, string) result

--- a/lib/leader.ml
+++ b/lib/leader.ml
@@ -227,7 +227,7 @@ let request_handlers t =
   handlers
 
 
-let run ~conf ~apply_log ~state () =
+let run ~conf ~apply_log ~state =
   init ~conf ~apply_log ~state >>= fun t ->
   VolatileState.update_leader_id t.state.common.volatile_state ~logger:t.logger
     t.conf.node_id;

--- a/lib/leader.mli
+++ b/lib/leader.mli
@@ -4,5 +4,4 @@ val run :
   conf:Conf.t ->
   apply_log:Base.apply_log ->
   state:State.common ->
-  unit ->
   (Base.mode Lwt.t, string) result

--- a/lib/oraft.ml
+++ b/lib/oraft.ml
@@ -27,9 +27,9 @@ let process ~conf ~logger ~apply_log ~state : unit Lwt.t =
   let exec next_mode =
     VolatileState.update_mode state.volatile_state ~logger next_mode;
     match next_mode with
-    | FOLLOWER -> Follower.run ~conf ~apply_log ~state ()
-    | CANDIDATE -> Candidate.run ~conf ~apply_log ~state ()
-    | LEADER -> Leader.run ~conf ~apply_log ~state ()
+    | FOLLOWER -> Follower.run ~conf ~apply_log ~state
+    | CANDIDATE -> Candidate.run ~conf ~apply_log ~state
+    | LEADER -> Leader.run ~conf ~apply_log ~state
   in
   let rec loop next_mode =
     match exec next_mode with

--- a/lib/oraft.ml
+++ b/lib/oraft.ml
@@ -7,7 +7,6 @@ type current_state = { mode : mode; term : int; leader : leader_node option }
 
 type t = {
   conf : Conf.t;
-  process : unit Lwt.t;
   post_command : string -> bool Lwt.t;
   current_state : unit -> current_state;
 }
@@ -24,19 +23,19 @@ let state ~(conf : Conf.t) ~logger =
   | Error msg -> Error msg
 
 
-let process ~conf ~logger ~apply_log ~state ~state_exec : unit Lwt.t =
-  let rec loop state_exec =
-    match state_exec () with
-    | Ok next_mode ->
-        let%lwt next = next_mode in
-        let next_state_exec =
-          VolatileState.update_mode state.volatile_state ~logger next;
-          match next with
-          | FOLLOWER -> Follower.run ~conf ~apply_log ~state
-          | CANDIDATE -> Candidate.run ~conf ~apply_log ~state
-          | LEADER -> Leader.run ~conf ~apply_log ~state
-        in
-        loop next_state_exec
+let process ~conf ~logger ~apply_log ~state : unit Lwt.t =
+  let exec next_mode =
+    VolatileState.update_mode state.volatile_state ~logger next_mode;
+    match next_mode with
+    | FOLLOWER -> Follower.run ~conf ~apply_log ~state ()
+    | CANDIDATE -> Candidate.run ~conf ~apply_log ~state ()
+    | LEADER -> Leader.run ~conf ~apply_log ~state ()
+  in
+  let rec loop next_mode =
+    match exec next_mode with
+    | Ok next ->
+        let%lwt next_mode = next in
+        loop next_mode
     | Error msg ->
         let msg =
           sprintf "Failed to process. Starting from %s again. error:[%s]"
@@ -44,9 +43,9 @@ let process ~conf ~logger ~apply_log ~state ~state_exec : unit Lwt.t =
             msg
         in
         Logger.error logger ~loc:__LOC__ msg;
-        loop (Follower.run ~conf ~apply_log ~state)
+        loop FOLLOWER
   in
-  loop state_exec
+  loop FOLLOWER
 
 
 let post_command ~(conf : Conf.t) ~logger ~state s =
@@ -93,14 +92,10 @@ let start ~conf_file ~apply_log =
   | Ok state ->
       Logger.info logger ~loc:__LOC__ "Starting Oraft";
       let post_command = post_command ~conf ~logger ~state in
-      let initial_state_exec = Follower.run ~conf ~apply_log ~state in
+      ignore (process ~conf ~logger ~apply_log ~state);
       Ok
         {
           conf;
-          (* TODO: This isn't useful for users...? If so, we can simplify `process` *)
-          process =
-            process ~conf ~logger ~apply_log ~state
-              ~state_exec:initial_state_exec;
           post_command;
           current_state =
             (fun () ->

--- a/lib/oraft.mli
+++ b/lib/oraft.mli
@@ -8,7 +8,6 @@ type current_state = {
 
 type t = {
   conf : Conf.t;
-  process : unit Lwt.t;
   post_command : string -> bool Lwt.t;
   current_state : unit -> current_state;
 }


### PR DESCRIPTION
- Remove `process` from `Oraft.t`
- Remove the unit argument from `Follower`, `Candidate` and `Leader`